### PR TITLE
Make dependency constrains less strict

### DIFF
--- a/sphinxcontrib/requirements.txt
+++ b/sphinxcontrib/requirements.txt
@@ -1,2 +1,2 @@
-docutils==0.17.1
-Sphinx==4.4.0
+docutils>=0.17.1
+Sphinx>=4.4.0


### PR DESCRIPTION
Hi.

Using `dependency==version` in requirements.txt is okay for applications, but definitely not for libraries. This prohibits installing `sphins-plantuml` with latest sphinx version, e.g. 7.x, because library requires exactly sphinx==4.4.0.

Here I've relaxed dependency versions, they are low boundaries now instead of strict values.